### PR TITLE
chore: change default branch to main

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        track: [master, 17, 16, 14, 12]
+        track: [main, 17, 16, 14, 12]
     name: Check branch
     runs-on: ubuntu-latest
 
@@ -20,13 +20,13 @@ jobs:
         with:
           ref: node${{ matrix.track }}
           fetch-depth: 0
-        if: ${{ matrix.track != 'master' }}
+        if: ${{ matrix.track != 'main' }}
 
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-        if: ${{ matrix.track == 'master' }}
+        if: ${{ matrix.track == 'main' }}
 
       - name: Init git config
         run: |
@@ -44,8 +44,8 @@ jobs:
 
       - name: Sync Release
         run: ./snapcraft.yaml.sh -r${{ matrix.track }} -gnode${{ matrix.track }}
-        if: ${{ matrix.track != 'master' }}
+        if: ${{ matrix.track != 'main' }}
 
       - name: Sync Edge
-        run: ./snapcraft.yaml.sh -gmaster
-        if: ${{ matrix.track == 'master' }}
+        run: ./snapcraft.yaml.sh -gmain
+        if: ${{ matrix.track == 'main' }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 # Code of Conduct
 
 The Node.js Code of Conduct, which applies to this project, can be found at
-https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md.
+https://github.com/nodejs/admin/blob/main/CODE_OF_CONDUCT.md.

--- a/snapcraft.yaml.sh
+++ b/snapcraft.yaml.sh
@@ -22,6 +22,10 @@ while getopts "r:g:" opt; do
       echo "Pushing to git $OPTARG" >&2
       UPDATE_GIT=yes
       GIT_BRANCH=$OPTARG
+      REMOTE_BRANCH=$GIT_BRANCH
+      if [ "X${GIT_BRANCH}" = "Xmain" ]; then
+        REMOTE_BRANCH=master
+      fi
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -120,5 +124,5 @@ if [ "X${UPDATE_GIT}" = "Xyes" ] && [ -n "$(git status --porcelain $__dirname)" 
   echo "Updating git repo and pushing ..."
   git commit $__dirname -m "snap: (auto) updated to ${NODE_VERSION}"
   git push origin $GIT_BRANCH
-  git push launchpad $GIT_BRANCH
+  git push launchpad $GIT_BRANCH:$REMOTE_BRANCH
 fi


### PR DESCRIPTION
Supersedes https://github.com/nodejs/snap/pull/17.

We are going through all of the Node.js repositories to rename the
primary branch to main.

This PR updates all of the references to the default branch that
need to be updated at the same time that we rename the branch. The
Launchpad side is, for now, unchanged as are references to the
master branch of the core nodejs/node repository.

Refs: https://github.com/nodejs/node/issues/33864

---

@mhdawson and I spent some time looking at what would be required to do the rename and we think it's possible to do the rename on the GitHub side first while leaving Launchpad untouched -- i.e. we rename `master`->`main` here but still push to `master` in Launchpad.