### PR TITLE
fix: update to gcc-10

### DIFF
--- a/snapcraft.yaml.sh
+++ b/snapcraft.yaml.sh
@@ -80,14 +80,14 @@ apps:
     command: bin/yarn.js
 
 parts:
-  gcc-8:
+  gcc-10:
     plugin: nil
     override-pull: 'true'
     override-build: |
       sudo apt --yes install software-properties-common
       sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
       sudo apt update
-      sudo apt --yes install gcc-8 g++-8 python3-distutils
+      sudo apt --yes install gcc-10 g++-10 python3-distutils
     override-stage: 'true'
     override-prime: 'true'
   node:
@@ -97,9 +97,9 @@ parts:
     make-parameters:
       - V=
     override-build: |
-      export CC="gcc-8"
-      export CXX="g++-8"
-      export LINK="g++-8"
+      export CC="gcc-10"
+      export CXX="g++-10"
+      export LINK="g++-10"
       export V=
       ./configure --verbose --prefix=/ --release-urlbase=https://nodejs.org/download/${NODE_DISTTYPE}/ --tag=${NODE_TAG}
       snapcraftctl build


### PR DESCRIPTION
Sorry to be doing these fixes by PR but I'm having to rely on launchpad to see it working or note and my `core22` update failed: https://launchpadlibrarian.net/665400901/buildlog_snap_ubuntu_jammy_arm64_nodeedge_BUILDING.txt.gz

gcc-8 no longer available, but gcc-10 is and it should be a good partner upgrade I think, especially since we recommend it now! https://github.com/nodejs/node/blob/main/BUILDING.md