### PR TITLE
snap: modernise snapcraft.yaml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -20,31 +20,31 @@ apps:
   yarnpkg:
     command: bin/yarn.js
 
+package-repositories:
+  - type: apt
+    ppa: ubuntu-toolchain-r/test
+
 parts:
-  gcc-10:
-    plugin: nil
-    override-pull: 'true'
-    override-build: |
-      sudo apt --yes install software-properties-common
-      sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
-      sudo apt --yes install gcc-10 g++-10 python3-distutils
-    override-stage: 'true'
-    override-prime: 'true'
   node:
     plugin: make
     source-type: tar
     source: https://nodejs.org/download/nightly/v22.0.0-nightly2024032929de7f82cd/node-v22.0.0-nightly2024032929de7f82cd.tar.gz
+    build-packages:
+      - gcc-10
+      - g++-10
+      - python3-distutils
+    build-environment:
+      - CC: gcc-10
+      - CXX: g++-10
+      - LINK: g++-10
+      - V: ""
     make-parameters:
       - V=
     override-build: |
-      export CC="gcc-10"
-      export CXX="g++-10"
-      export LINK="g++-10"
-      export V=
       ./configure --verbose --prefix=/ --release-urlbase=https://nodejs.org/download/nightly/ --tag=nightly2024032929de7f82cd
-      snapcraftctl build
-      mkdir -p $SNAPCRAFT_PART_INSTALL/etc
-      echo "prefix = /usr/local" >> $SNAPCRAFT_PART_INSTALL/etc/npmrc
+      craftctl default
+      mkdir -p $CRAFT_PART_INSTALL/etc
+      echo "prefix = /usr/local" >> $CRAFT_PART_INSTALL/etc/npmrc
   yarn:
     source-type: tar
     source: https://yarnpkg.com/latest.tar.gz
@@ -52,6 +52,6 @@ parts:
     # Yarn has a problem with lifecycle scripts when used inside snap, they don't complete properly, with exit code !=0.
     # Replacing the spinner with proper stdio appears to fix it.
     override-build: |
-      snapcraftctl build
-      chmod -R g-s $SNAPCRAFT_PART_INSTALL
-      sed -i "s/var stdio = spinner ? undefined : 'inherit';/var stdio = 'inherit';/" $SNAPCRAFT_PART_INSTALL/lib/cli.js
+      craftctl default
+      chmod -R g-s $CRAFT_PART_INSTALL
+      sed -i "s/var stdio = spinner ? undefined : 'inherit';/var stdio = 'inherit';/" $CRAFT_PART_INSTALL/lib/cli.js

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: node
-version: '22.0.0-nightly2024032929de7f82'
+version: '22.0.0-nightly202404019efc84a2'
 summary: Node.js
 description: |
   A JavaScript runtime built on Chrome's V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js' package ecosystem, npm, is the largest ecosystem of open source libraries in the world. https://nodejs.org/
@@ -28,7 +28,7 @@ parts:
   node:
     plugin: make
     source-type: tar
-    source: https://nodejs.org/download/nightly/v22.0.0-nightly2024032929de7f82cd/node-v22.0.0-nightly2024032929de7f82cd.tar.gz
+    source: https://nodejs.org/download/nightly/v22.0.0-nightly202404019efc84a2cb/node-v22.0.0-nightly202404019efc84a2cb.tar.gz
     build-packages:
       - gcc-10
       - g++-10
@@ -41,7 +41,7 @@ parts:
     make-parameters:
       - V=
     override-build: |
-      ./configure --verbose --prefix=/ --release-urlbase=https://nodejs.org/download/nightly/ --tag=nightly2024032929de7f82cd
+      ./configure --verbose --prefix=/ --release-urlbase=https://nodejs.org/download/nightly/ --tag=nightly202404019efc84a2cb
       craftctl default
       mkdir -p $CRAFT_PART_INSTALL/etc
       echo "prefix = /usr/local" >> $CRAFT_PART_INSTALL/etc/npmrc

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -30,6 +30,8 @@ parts:
     source-type: tar
     source: https://nodejs.org/download/nightly/v22.0.0-nightly202404019efc84a2cb/node-v22.0.0-nightly202404019efc84a2cb.tar.gz
     build-packages:
+      # Ensure these and the build environment below match the minimum GCC and G++ versions for this Node release.
+      # https://github.com/nodejs/node/blob/main/BUILDING.md#building-nodejs-on-supported-platforms
       - gcc-10
       - g++-10
       - python3-distutils

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -20,10 +20,6 @@ apps:
   yarnpkg:
     command: bin/yarn.js
 
-package-repositories:
-  - type: apt
-    ppa: ubuntu-toolchain-r/test
-
 parts:
   node:
     plugin: make

--- a/snapcraft.yaml.sh
+++ b/snapcraft.yaml.sh
@@ -74,31 +74,31 @@ apps:
   yarnpkg:
     command: bin/yarn.js
 
+package-repositories:
+  - type: apt
+    ppa: ubuntu-toolchain-r/test
+
 parts:
-  gcc-10:
-    plugin: nil
-    override-pull: 'true'
-    override-build: |
-      sudo apt --yes install software-properties-common
-      sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
-      sudo apt --yes install gcc-10 g++-10 python3-distutils
-    override-stage: 'true'
-    override-prime: 'true'
   node:
     plugin: make
     source-type: tar
     source: https://nodejs.org/download/${NODE_DISTTYPE}/v${NODE_VERSION}/node-v${NODE_VERSION}.tar.gz
+    build-packages:
+      - gcc-10
+      - g++-10
+      - python3-distutils
+    build-environment:
+      - CC: gcc-10
+      - CXX: g++-10
+      - LINK: g++-10
+      - V: ""
     make-parameters:
       - V=
     override-build: |
-      export CC="gcc-10"
-      export CXX="g++-10"
-      export LINK="g++-10"
-      export V=
       ./configure --verbose --prefix=/ --release-urlbase=https://nodejs.org/download/${NODE_DISTTYPE}/ --tag=${NODE_TAG}
-      snapcraftctl build
-      mkdir -p \$SNAPCRAFT_PART_INSTALL/etc
-      echo "prefix = /usr/local" >> \$SNAPCRAFT_PART_INSTALL/etc/npmrc
+      craftctl default
+      mkdir -p \$CRAFT_PART_INSTALL/etc
+      echo "prefix = /usr/local" >> \$CRAFT_PART_INSTALL/etc/npmrc
   yarn:
     source-type: tar
     source: https://yarnpkg.com/latest.tar.gz
@@ -106,8 +106,8 @@ parts:
     # Yarn has a problem with lifecycle scripts when used inside snap, they don't complete properly, with exit code !=0.
     # Replacing the spinner with proper stdio appears to fix it.
     override-build: |
-      snapcraftctl build
-      chmod -R g-s \$SNAPCRAFT_PART_INSTALL
+      craftctl default
+      chmod -R g-s \$CRAFT_PART_INSTALL
       sed -i "s/var stdio = spinner ? undefined : 'inherit';/var stdio = 'inherit';/" \$SNAPCRAFT_PART_INSTALL/lib/cli.js
 EOF
 

--- a/snapcraft.yaml.sh
+++ b/snapcraft.yaml.sh
@@ -108,7 +108,7 @@ parts:
     override-build: |
       craftctl default
       chmod -R g-s \$CRAFT_PART_INSTALL
-      sed -i "s/var stdio = spinner ? undefined : 'inherit';/var stdio = 'inherit';/" \$SNAPCRAFT_PART_INSTALL/lib/cli.js
+      sed -i "s/var stdio = spinner ? undefined : 'inherit';/var stdio = 'inherit';/" \$CRAFT_PART_INSTALL/lib/cli.js
 EOF
 
 if [ "X${UPDATE_GIT}" = "Xyes" ] && [ -n "$(git status --porcelain "$__dirname")" ]; then

--- a/snapcraft.yaml.sh
+++ b/snapcraft.yaml.sh
@@ -84,6 +84,8 @@ parts:
     source-type: tar
     source: https://nodejs.org/download/${NODE_DISTTYPE}/v${NODE_VERSION}/node-v${NODE_VERSION}.tar.gz
     build-packages:
+      # Ensure these and the build environment below match the minimum GCC and G++ versions for this Node release.
+      # https://github.com/nodejs/node/blob/main/BUILDING.md#building-nodejs-on-supported-platforms
       - gcc-10
       - g++-10
       - python3-distutils

--- a/snapcraft.yaml.sh
+++ b/snapcraft.yaml.sh
@@ -74,10 +74,6 @@ apps:
   yarnpkg:
     command: bin/yarn.js
 
-package-repositories:
-  - type: apt
-    ppa: ubuntu-toolchain-r/test
-
 parts:
   node:
     plugin: make

--- a/snapcraft.yaml.sh
+++ b/snapcraft.yaml.sh
@@ -3,6 +3,7 @@
 set -euxo pipefail
 
 __dirname="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UPDATE_GIT=no
 
 while getopts "r:g:" opt; do
   case $opt in


### PR DESCRIPTION
This adjusts the snap to use more modern snapcraft features, which should also help make it easier to do a core24 migration. The build toolchain is unchanged, and the resulting snap should be identical.

Changes:
- Instead of installing `software-properties-common` and adding the repo + installing additional packages using an `override-build` script, uses `package-repositories` to add the repository and `build-packages` to install the packages.
- Sets the build environment using the `build-environment` keyword
- Uses `craftctl` instead of `snapcraftctl`
- Uses `CRAFT_*` variables rather than `SNAPCRAFT_*` variables

The primary motivation behind this is that people often look at big, widely-used projects such as nodejs for help when building their `snapcraft.yaml` files, so using the latest best practices will help encourage others to do so.