### PR TITLE
chore: give GHA write permission

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,5 +1,8 @@
 name: Snap Cron
 
+permissions:
+  contents: write
+
 on:
   push:
   schedule:


### PR DESCRIPTION
I'm not sure why this has started failing but I'm now getting cron failure notifications every hour, and I can't set this in the repo settings. Maybe something was changed at the org level?