### PR TITLE
fix: add libstdc++6 to stage-packages in snapcraft.yaml.sh (node22)

### DIFF
--- a/snapcraft.yaml.sh
+++ b/snapcraft.yaml.sh
@@ -91,6 +91,8 @@ parts:
       - CXX: g++-10
       - LINK: g++-10
       - V: ""
+    stage-packages:
+      - libstdc++6
     make-parameters:
       - V=
     override-build: |


### PR DESCRIPTION
Not sure if this will actually help, but we can give it a try. This is only for node22 branch for now, we can port it to others if it helps.

Ref: https://github.com/nodejs/snap/issues/82
Ref: https://github.com/nodejs/snap/issues/54