### PR TITLE
chore: explicit linking into core22 libc & stage dependencies

### DIFF
--- a/snapcraft.yaml.sh
+++ b/snapcraft.yaml.sh
@@ -86,6 +86,10 @@ parts:
       - gcc-10
       - g++-10
       - python3-distutils
+    stage-packages:
+      # Include C++ runtime libraries that Node.js needs
+      - libstdc++6
+      - libgcc-s1
     build-environment:
       - CC: gcc-10
       - CXX: g++-10
@@ -95,6 +99,7 @@ parts:
       - libstdc++6
     make-parameters:
       - V=
+      - LDFLAGS=-Wl,-dynamic-linker=/snap/core22/current/lib64/ld-linux-x86-64.so.2 -Wl,-rpath=\$ORIGIN/../lib/x86_64-linux-gnu:\$ORIGIN/../usr/lib/x86_64-linux-gnu:/snap/core22/current/lib/x86_64-linux-gnu:/snap/core22/current/usr/lib/x86_64-linux-gnu
     override-build: |
       ./configure --verbose --prefix=/ --release-urlbase=https://nodejs.org/download/${NODE_DISTTYPE}/ --tag=${NODE_TAG}
       craftctl default


### PR DESCRIPTION
Another attempt at dealing with https://github.com/nodejs/snap/issues/54

I think the issue is that because we are using classic confinement we're not linking to the core22 libraries, but the host libraries, so we'll try and link explicitly.