### PR TITLE
chore: explicit linking into core22 libc & stage dependencies (#84)

### DIFF
--- a/snapcraft.yaml.sh
+++ b/snapcraft.yaml.sh
@@ -85,6 +85,10 @@ parts:
       # https://github.com/nodejs/node/blob/main/BUILDING.md#building-nodejs-on-supported-platforms
       - gcc-14
       - g++-14
+    stage-packages:
+      # Include C++ runtime libraries that Node.js needs
+      - libstdc++6
+      - libgcc-s1
     build-environment:
       - CC: gcc-14
       - CXX: g++-14
@@ -92,6 +96,7 @@ parts:
       - V: ""
     make-parameters:
       - V=
+      - LDFLAGS=-Wl,-dynamic-linker=/snap/core24/current/lib64/ld-linux-x86-64.so.2 -Wl,-rpath=\$ORIGIN/../lib/x86_64-linux-gnu:\$ORIGIN/../usr/lib/x86_64-linux-gnu:/snap/core24/current/lib/x86_64-linux-gnu:/snap/core24/current/usr/lib/x86_64-linux-gnu
     override-build: |
       ./configure --verbose --prefix=/ --release-urlbase=https://nodejs.org/download/${NODE_DISTTYPE}/ --tag=${NODE_TAG}
       craftctl default


### PR DESCRIPTION
Same as #84 but for node24; I'll also cherry-pick this to the main/edge branch