### PR TITLE
fix: package official Node.js runtime artifacts

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,32 +5,39 @@ permissions:
 
 on:
   workflow_dispatch:
-  push:
   schedule:
-    - cron:  '0 * * * *'
+    - cron: '0 * * * *'
 
 jobs:
   check:
+    name: Check ${{ matrix.branch }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: snap-sync-${{ matrix.branch }}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:
-        track: [main, 26, 24, 22]
-    name: Check branch
-    runs-on: ubuntu-latest
+        include:
+          - branch: main
+            launchpad_branch: master
+            release: ''
+          - branch: node26
+            launchpad_branch: node26
+            release: '26'
+          - branch: node24
+            launchpad_branch: node24
+            release: '24'
+          - branch: node22
+            launchpad_branch: node22
+            release: '22'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
-          ref: node${{ matrix.track }}
+          ref: ${{ matrix.branch }}
           fetch-depth: 0
-        if: ${{ matrix.track != 'main' }}
-
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-        if: ${{ matrix.track == 'main' }}
 
       - name: Init git config
         run: |
@@ -49,10 +56,30 @@ jobs:
           ssh-keyscan git.launchpad.net >> ~/.ssh/known_hosts
           ssh-keygen -qlF git.launchpad.net | grep -xF 'git.launchpad.net RSA SHA256:UNOzlP66WpDuEo34Wgs8mewypV0UzqHLsIFoqwe8dYo'
 
-      - name: Sync Release
-        run: ./snapcraft.yaml.sh -r${{ matrix.track }} -gnode${{ matrix.track }}
-        if: ${{ matrix.track != 'main' }}
+      - name: Generate Snap definition
+        id: generate
+        env:
+          RELEASE: ${{ matrix.release }}
+        run: |
+          args=()
+          if [[ -n "$RELEASE" ]]; then
+            args=(-r "$RELEASE")
+          fi
+          output="$(./snapcraft.yaml.sh "${args[@]}")"
+          printf '%s\n' "$output"
+          version="$(printf '%s\n' "$output" | awk -F= '$1 == "NODE_VERSION" { print $2 }')"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Sync Edge
-        run: ./snapcraft.yaml.sh -gmain
-        if: ${{ matrix.track == 'main' }}
+      - name: Publish changes
+        env:
+          BRANCH: ${{ matrix.branch }}
+          LAUNCHPAD_BRANCH: ${{ matrix.launchpad_branch }}
+          VERSION: ${{ steps.generate.outputs.version }}
+        run: |
+          if ! git diff --quiet -- snapcraft.yaml; then
+            git add snapcraft.yaml
+            git commit -m "snap: (auto) updated to $VERSION"
+            git push origin "HEAD:$BRANCH"
+          fi
+          git push launchpad "HEAD:$LAUNCHPAD_BRANCH"

--- a/README.md
+++ b/README.md
@@ -63,21 +63,27 @@ This repository contains a main script [snapcraft.yaml.sh](./snapcraft.yaml.sh),
 
 This repository contains a branch for each track/channel published to the Snap store. The `main` branch represents the "edge" channel, while the `nodeXX` branches represent the major release lines (e.g. `node14` for Node.js 14.x.x). These release lines are published to the "stable" channel on a track named after the release line. e.g. Node.js 14.x.x releases are published as `14/stable`.
 
-Each branch, contains both a snapcraft.yaml.sh script and a snapcraft.yaml definition file. These are different between releases as compile requirements change.
+Each branch contains its own snapcraft.yaml.sh script and generated snapcraft.yaml definition. These may differ as release artifact availability and source-build requirements change.
 
 **Changes to the build definition should be made in the snapcraft.yaml.sh script for the relevant branch.** For changes to "edge" (nightly / main) releases, change the snapcraft.yaml.sh script on the `main` branch. For changes to the "14/stable" releases, change the snapcraft.yaml.sh on the `node14` branch. All changes should be made via Pull Request targeting the appropriate branch.
 
 ### Watching for releases
 
-This repository uses GitHub Actions on a timer (cron) schedule. See [.github/workflows/cron.yml](./.github/workflows/cron.yml). The Action configuration is set to run for the `main` branch and for each major release line that is currently being published to the Snap store using a matrix configuration.
+This repository uses an hourly or manually dispatched GitHub Actions workflow. See [.github/workflows/cron.yml](./.github/workflows/cron.yml). Its matrix contains `main` and each major release line currently published to the Snap store. Jobs for the same branch are serialized.
 
-Upon run, for each branch, this repository is cloned and the snapcraft.yaml.sh script is run with arguments that tell it what to do. `-rXX` is supplied to specify the release line (e.g. `-r14`, this is omitted for "edge" releases) and `-gnode14` is supplied to specify the Git branch to operate on (more on this below).
+For each branch, the workflow checks out its current tip and runs snapcraft.yaml.sh. `-rXX` selects a release line (for example, `-r24`); the option is omitted for edge releases.
 
-The snapcraft.yaml.sh script will fetch the relevant releases list, either https://nodejs.org/download/release/index.tab for regular releases, or https://nodejs.org/download/nightly/index.tab for "edge" releases. The latest release for the given release line (or latest nightly release) is then used to build the snapcraft.yaml Snap definition file.
+The generator reads either the [release index](https://nodejs.org/download/release/index.tab) or [nightly index](https://nodejs.org/download/nightly/index.tab). It selects the newest entry containing every artifact required by that branch, skipping newer incomplete entries. It then requires each selected filename in the release's `SHASUMS256.txt` and embeds the checksums in snapcraft.yaml.
 
-In most cases, building a new snapcraft.yaml file will result in the same file already in this repository. But when there is a new release for that release line, the file will differ. When it differs it is committed and pushed back to this repository on the appropriate branch.
+When snapcraft.yaml changes, the workflow commits and pushes it to the corresponding GitHub branch. The same branch tip is always pushed to Launchpad, allowing a prior failed synchronization to recover on the next run. Workflow runs do not trigger from their own pushes.
 
-When changes are made, the commit is _also_ pushed to Launchpad to build the Snap.
+### Runtime artifacts and architectures
+
+On amd64, arm64 and s390x, the Snap packages Node.js' official Linux binaries without changing their ELF interpreter or runtime search paths. These binaries retain Node.js' upstream Linux ABI baseline and load libc and libstdc++ from the host, matching a normally installed Node.js runtime. Node.js 25 and later also require `libatomic.so.1`; the Snap provides only that library in an isolated directory without redirecting other runtime libraries.
+
+Node.js does not publish an armv7 Linux binary from Node.js 24 onward. The armhf Snap therefore remains an Experimental source build and uses Snapcraft's architecture-aware ELF patching against the base Snap. Node.js 22 uses its official armv7l artifact instead. This split also provides a documented source-build path for future Experimental architectures without weakening the supported architectures' compatibility.
+
+The Snap prepends its direct `bin` directory to `PATH` so npm lifecycle scripts and child processes resolve `node`, `npm` and `npx` without re-entering the `/snap/bin` launcher. This does not affect external programs that explicitly invoke `/snap/bin/node`.
 
 ### Building Snaps
 
@@ -93,9 +99,9 @@ The process for adding new release lines when the Node.js Release team begin one
 
 1. Request a new Track for the "node" Snap in the Snapcraft forum in the ["Store requests" section](https://forum.snapcraft.io/c/store-requests). The track should be the major release line number (e.g. `14`). The "node" Snap has fast-track approval and is usually authorized within 24 hours by the administrators. This step needs to be performed in order to upload to a new track. An example of this for `14` can be seen here: https://forum.snapcraft.io/t/track-request-for-node-14-fast-track-please/16842/3
 2. Create a new branch in this repository, named `nodeXX` where `XX` is the release line number.
-3. Edit [snapcraft.yaml.sh](./snapcraft.yaml.sh) _if_ required for system configuration required to build the new version. In most cases this is not necessary and the `main` version can be copied. Where the compiler minimums change, the equivalent changes may need to be made in the script.
+3. Edit [snapcraft.yaml.sh](./snapcraft.yaml.sh) if artifact availability or the Experimental source-build toolchain differs from `main`. In most cases the `main` version can be copied unchanged.
 4. Edit [.github/workflows/cron.yml](./.github/workflows/cron.yml) to add the new release line to the matrix.
-5. Start a build (manually, or wait for the GitHub Action to trigger by cron), which will update the snapcraft.yaml file for that branch correctly _and_ push the new branch to https://code.launchpad.net/node-snap where it can be further configured.
+5. Run the GitHub workflow manually or wait for its hourly schedule. It will update snapcraft.yaml and push the branch to https://code.launchpad.net/node-snap.
 6. Navigate to https://code.launchpad.net/node-snap and into the new branch and click on "Create snap package".
   - The "name" should be the same as the branch
   - The "series" should be inferred from snapcraft.yaml

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,6 +80,7 @@ parts:
 
   node-experimental:
     plugin: make
+    source: .
     build-attributes:
       - enable-patchelf
     build-snaps:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: node
-version: '27.0.0-nightly2026071214166a59'
+version: '27.0.0-nightly202607116eff6797'
 summary: Node.js
 description: |
   A JavaScript runtime built on Chrome's V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js' package ecosystem, npm, is the largest ecosystem of open source libraries in the world. https://nodejs.org/
@@ -7,6 +7,10 @@ description: |
 grade: stable
 confinement: classic
 base: core24
+
+environment:
+  PATH: '$SNAP/bin:$PATH'
+  LD_LIBRARY_PATH: '$SNAP/lib/runtime'
 
 apps:
   node:
@@ -17,21 +21,80 @@ apps:
     command: bin/npx
 
 parts:
-  node:
-    plugin: make
-    source-type: tar
-    source: https://nodejs.org/download/nightly/v27.0.0-nightly2026071214166a59cc/node-v27.0.0-nightly2026071214166a59cc.tar.gz
-    build-snaps:
-      - rustup/latest/stable
+  node-prebuilt:
+    plugin: nil
+    build-attributes:
+      - no-patchelf
     build-packages:
-      # Ensure these and the build environment below match the minimum GCC and G++ versions for this Node release.
-      # https://github.com/nodejs/node/blob/main/BUILDING.md#building-nodejs-on-supported-platforms
-      - gcc-14
-      - g++-14
+      - curl
+      - xz-utils
+    override-pull: |
+      case "$CRAFT_ARCH_BUILD_FOR" in
+        amd64)
+          archive="node-v27.0.0-nightly202607116eff6797be-linux-x64.tar.xz"
+          checksum="dd18b9ef4eea2fa1a9587e9a700d919030604a9c7a1669cfadbcf19bf32f99ec"
+          ;;
+        arm64)
+          archive="node-v27.0.0-nightly202607116eff6797be-linux-arm64.tar.xz"
+          checksum="11f342b92818f120647725b2ffe18f8bdcb433a194a6bbb9c4e3264776f06ab0"
+          ;;
+        s390x)
+          archive="node-v27.0.0-nightly202607116eff6797be-linux-s390x.tar.xz"
+          checksum="ee106f69837264acb586ecd071b29d64574495928418a5c3c21cf09b379be3a8"
+          ;;
+        armhf)
+          if [ "source" != "prebuilt" ]; then
+            exit 0
+          fi
+          archive=""
+          checksum=""
+          ;;
+        *)
+          echo "Unsupported architecture: $CRAFT_ARCH_BUILD_FOR" >&2
+          exit 1
+          ;;
+      esac
+      cd "$CRAFT_PART_SRC"
+      curl -sSL --show-error --fail --proto '=https' --tlsv1.2         --output "$archive" "https://nodejs.org/download/nightly/v27.0.0-nightly202607116eff6797be/$archive"
+      echo "$checksum  $archive" | sha256sum --check --strict -
+      tar -xJf "$archive" --strip-components=1
+      rm "$archive"
+    override-build: |
+      if [ "$CRAFT_ARCH_BUILD_FOR" = "armhf" ] && [ "source" != "prebuilt" ]; then
+        exit 0
+      fi
+      craftctl default
+      cp -a "$CRAFT_PART_SRC"/. "$CRAFT_PART_INSTALL"/
+      mkdir -p "$CRAFT_PART_INSTALL/etc"
+      echo "prefix = /usr/local" >> "$CRAFT_PART_INSTALL/etc/npmrc"
+
+  node-libatomic:
+    plugin: nil
+    build-attributes:
+      - no-patchelf
+    build-packages:
+      - libatomic1
+    override-build: |
+      craftctl default
+      install -Dm644         "/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libatomic.so.1"         "$CRAFT_PART_INSTALL/lib/runtime/libatomic.so.1"
+
+  node-experimental:
+    plugin: make
+    build-attributes:
+      - enable-patchelf
+    build-snaps:
+      - to armhf:
+          - rustup/latest/stable
+    build-packages:
+      - curl
+      - xz-utils
+      - to armhf:
+          - gcc-14
+          - g++-14
     stage-packages:
-      # Include C++ runtime libraries that Node.js needs
-      - libstdc++6
-      - libgcc-s1
+      - to armhf:
+          - libstdc++6
+          - libgcc-s1
     build-environment:
       - CC: gcc-14
       - CXX: g++-14
@@ -40,10 +103,22 @@ parts:
       - V: ""
     make-parameters:
       - V=
-      - LDFLAGS=-Wl,-rpath=/snap/node/current/lib/$(SNAPCRAFT_ARCH_TRIPLET):/snap/node/current/usr/lib/$(SNAPCRAFT_ARCH_TRIPLET):/snap/core24/current/lib/$(SNAPCRAFT_ARCH_TRIPLET):/snap/core24/current/usr/lib/$(SNAPCRAFT_ARCH_TRIPLET)
+    override-pull: |
+      if [ "source" != "source" ] || [ "$CRAFT_ARCH_BUILD_FOR" != "armhf" ]; then
+        exit 0
+      fi
+      cd "$CRAFT_PART_SRC"
+      archive="node-v27.0.0-nightly202607116eff6797be.tar.xz"
+      curl -sSL --show-error --fail --proto '=https' --tlsv1.2         --output "$archive" "https://nodejs.org/download/nightly/v27.0.0-nightly202607116eff6797be/$archive"
+      echo "6afc7aa833cc4e3427b5e9c8d76e11c2c5977ac12d930362b0d03e62530a45f7  $archive" | sha256sum --check --strict -
+      tar -xJf "$archive" --strip-components=1
+      rm "$archive"
     override-build: |
+      if [ "source" != "source" ] || [ "$CRAFT_ARCH_BUILD_FOR" != "armhf" ]; then
+        exit 0
+      fi
       rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal
-      ./configure --verbose --prefix=/ --release-urlbase=https://nodejs.org/download/nightly/ --tag=nightly2026071214166a59cc --v8-enable-temporal-support
+      ./configure --verbose --prefix=/ --release-urlbase=https://nodejs.org/download/nightly/ --tag=nightly202607116eff6797be --v8-enable-temporal-support
       craftctl default
-      mkdir -p $CRAFT_PART_INSTALL/etc
-      echo "prefix = /usr/local" >> $CRAFT_PART_INSTALL/etc/npmrc
+      mkdir -p "$CRAFT_PART_INSTALL/etc"
+      echo "prefix = /usr/local" >> "$CRAFT_PART_INSTALL/etc/npmrc"

--- a/snapcraft.yaml.sh
+++ b/snapcraft.yaml.sh
@@ -217,6 +217,7 @@ parts:
 
   node-experimental:
     plugin: make
+    source: .
     build-attributes:
       - enable-patchelf
     build-snaps:

--- a/snapcraft.yaml.sh
+++ b/snapcraft.yaml.sh
@@ -5,14 +5,77 @@ set -euxo pipefail
 __dirname="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 UPDATE_GIT=no
 
+select_node_version() {
+  local index_url="$1"
+  local major="$2"
+  local required_files="$3"
+
+  curl -sL --show-error --fail "$index_url" |
+    awk -F '\t' -v major="$major" -v required_files="$required_files" '
+      function includes(files, candidate, count, loop_index, values) {
+        count = split(files, values, ",")
+        for (loop_index = 1; loop_index <= count; loop_index++) {
+          if (values[loop_index] == candidate) {
+            return 1
+          }
+        }
+        return 0
+      }
+
+      NR > 1 && !selected && (major == "" || index($1, "v" major ".") == 1) {
+        required_count = split(required_files, required, ",")
+        complete = 1
+        for (required_index = 1; required_index <= required_count; required_index++) {
+          if (!includes($3, required[required_index])) {
+            complete = 0
+          }
+        }
+        if (complete) {
+          selected = 1
+          print substr($1, 2)
+        }
+      }
+
+      END {
+        if (!selected) {
+          exit 1
+        }
+      }
+    '
+}
+
+checksum_for() {
+  local filename="$1"
+
+  awk -v filename="$filename" '
+    $2 == filename {
+      found = 1
+      print $1
+      exit
+    }
+
+    END {
+      if (!found) {
+        exit 1
+      }
+    }
+  ' <<< "$NODE_SHASUMS"
+}
+
+NODE_REQUIRED_FILES="src,linux-arm64,linux-s390x,linux-x64"
+NODE_ARMHF_MODE=source
+
 while getopts "r:g:" opt; do
   case $opt in
     r)
       echo "Updating for latest $OPTARG release" >&2
-      # release
-      NODE_VERSION="$(curl -sL --show-error --fail https://nodejs.org/download/release/index.tab | awk 'BEGIN { found = 0 } /^v'"$OPTARG"'\..*[^a-z0-9]src[^a-z0-9]/ && !found { found = 1; print substr($1, 2) }')"
       NODE_DISTTYPE="release"
       NODE_TAG=""
+      if [ "$OPTARG" -le 22 ]; then
+        NODE_REQUIRED_FILES+=",linux-armv7l"
+        NODE_ARMHF_MODE=prebuilt
+      fi
+      NODE_VERSION="$(select_node_version "https://nodejs.org/download/release/index.tab" "$OPTARG" "$NODE_REQUIRED_FILES")"
       ;;
     g)
       echo "Pushing to git $OPTARG" >&2
@@ -29,13 +92,29 @@ while getopts "r:g:" opt; do
   esac
 done
 
-# not a release?
 if [ -z ${NODE_DISTTYPE+x} ]; then
-  # nightly
-  NODE_VERSION="$(curl -sL --show-error --fail https://nodejs.org/download/nightly/index.tab | awk 'BEGIN { found = 0 } /^v[1-9].*[^a-z0-9]src[^a-z0-9]/ && !found { found = 1; print substr($1, 2) }')"
   NODE_DISTTYPE="nightly"
+  NODE_VERSION="$(select_node_version "https://nodejs.org/download/nightly/index.tab" "" "$NODE_REQUIRED_FILES")"
   NODE_TAG="$(echo "$NODE_VERSION" | sed -E 's/^[^-]+-//')"
 fi
+
+NODE_DOWNLOAD_BASE="https://nodejs.org/download/${NODE_DISTTYPE}/v${NODE_VERSION}"
+NODE_SHASUMS="$(curl -sL --show-error --fail "${NODE_DOWNLOAD_BASE}/SHASUMS256.txt")"
+NODE_SOURCE_ARCHIVE="node-v${NODE_VERSION}.tar.xz"
+NODE_X64_ARCHIVE="node-v${NODE_VERSION}-linux-x64.tar.xz"
+NODE_ARM64_ARCHIVE="node-v${NODE_VERSION}-linux-arm64.tar.xz"
+NODE_S390X_ARCHIVE="node-v${NODE_VERSION}-linux-s390x.tar.xz"
+NODE_SOURCE_CHECKSUM="$(checksum_for "$NODE_SOURCE_ARCHIVE")"
+NODE_X64_CHECKSUM="$(checksum_for "$NODE_X64_ARCHIVE")"
+NODE_ARM64_CHECKSUM="$(checksum_for "$NODE_ARM64_ARCHIVE")"
+NODE_S390X_CHECKSUM="$(checksum_for "$NODE_S390X_ARCHIVE")"
+NODE_ARMHF_ARCHIVE=""
+NODE_ARMHF_CHECKSUM=""
+if [ "$NODE_ARMHF_MODE" = "prebuilt" ]; then
+  NODE_ARMHF_ARCHIVE="node-v${NODE_VERSION}-linux-armv7l.tar.xz"
+  NODE_ARMHF_CHECKSUM="$(checksum_for "$NODE_ARMHF_ARCHIVE")"
+fi
+
 
 echo "NODE_VERSION=$NODE_VERSION"
 echo "NODE_DISTTYPE=$NODE_DISTTYPE"
@@ -63,6 +142,10 @@ grade: stable
 confinement: classic
 base: core24
 
+environment:
+  PATH: '\$SNAP/bin:\$PATH'
+  LD_LIBRARY_PATH: '\$SNAP/lib/runtime'
+
 apps:
   node:
     command: bin/node
@@ -72,21 +155,83 @@ apps:
     command: bin/npx
 
 parts:
-  node:
-    plugin: make
-    source-type: tar
-    source: https://nodejs.org/download/${NODE_DISTTYPE}/v${NODE_VERSION}/node-v${NODE_VERSION}.tar.gz
-    build-snaps:
-      - rustup/latest/stable
+  node-prebuilt:
+    plugin: nil
+    build-attributes:
+      - no-patchelf
     build-packages:
-      # Ensure these and the build environment below match the minimum GCC and G++ versions for this Node release.
-      # https://github.com/nodejs/node/blob/main/BUILDING.md#building-nodejs-on-supported-platforms
-      - gcc-14
-      - g++-14
+      - curl
+      - xz-utils
+    override-pull: |
+      case "\$CRAFT_ARCH_BUILD_FOR" in
+        amd64)
+          archive="${NODE_X64_ARCHIVE}"
+          checksum="${NODE_X64_CHECKSUM}"
+          ;;
+        arm64)
+          archive="${NODE_ARM64_ARCHIVE}"
+          checksum="${NODE_ARM64_CHECKSUM}"
+          ;;
+        s390x)
+          archive="${NODE_S390X_ARCHIVE}"
+          checksum="${NODE_S390X_CHECKSUM}"
+          ;;
+        armhf)
+          if [ "${NODE_ARMHF_MODE}" != "prebuilt" ]; then
+            exit 0
+          fi
+          archive="${NODE_ARMHF_ARCHIVE}"
+          checksum="${NODE_ARMHF_CHECKSUM}"
+          ;;
+        *)
+          echo "Unsupported architecture: \$CRAFT_ARCH_BUILD_FOR" >&2
+          exit 1
+          ;;
+      esac
+      cd "\$CRAFT_PART_SRC"
+      curl -sSL --show-error --fail --proto '=https' --tlsv1.2 \
+        --output "\$archive" "${NODE_DOWNLOAD_BASE}/\$archive"
+      echo "\$checksum  \$archive" | sha256sum --check --strict -
+      tar -xJf "\$archive" --strip-components=1
+      rm "\$archive"
+    override-build: |
+      if [ "\$CRAFT_ARCH_BUILD_FOR" = "armhf" ] && [ "${NODE_ARMHF_MODE}" != "prebuilt" ]; then
+        exit 0
+      fi
+      craftctl default
+      cp -a "\$CRAFT_PART_SRC"/. "\$CRAFT_PART_INSTALL"/
+      mkdir -p "\$CRAFT_PART_INSTALL/etc"
+      echo "prefix = /usr/local" >> "\$CRAFT_PART_INSTALL/etc/npmrc"
+
+  node-libatomic:
+    plugin: nil
+    build-attributes:
+      - no-patchelf
+    build-packages:
+      - libatomic1
+    override-build: |
+      craftctl default
+      install -Dm644 \
+        "/usr/lib/\$CRAFT_ARCH_TRIPLET_BUILD_FOR/libatomic.so.1" \
+        "\$CRAFT_PART_INSTALL/lib/runtime/libatomic.so.1"
+
+  node-experimental:
+    plugin: make
+    build-attributes:
+      - enable-patchelf
+    build-snaps:
+      - to armhf:
+          - rustup/latest/stable
+    build-packages:
+      - curl
+      - xz-utils
+      - to armhf:
+          - gcc-14
+          - g++-14
     stage-packages:
-      # Include C++ runtime libraries that Node.js needs
-      - libstdc++6
-      - libgcc-s1
+      - to armhf:
+          - libstdc++6
+          - libgcc-s1
     build-environment:
       - CC: gcc-14
       - CXX: g++-14
@@ -95,13 +240,26 @@ parts:
       - V: ""
     make-parameters:
       - V=
-      - LDFLAGS=-Wl,-rpath=/snap/node/current/lib/\$(SNAPCRAFT_ARCH_TRIPLET):/snap/node/current/usr/lib/\$(SNAPCRAFT_ARCH_TRIPLET):/snap/core24/current/lib/\$(SNAPCRAFT_ARCH_TRIPLET):/snap/core24/current/usr/lib/\$(SNAPCRAFT_ARCH_TRIPLET)
+    override-pull: |
+      if [ "${NODE_ARMHF_MODE}" != "source" ] || [ "\$CRAFT_ARCH_BUILD_FOR" != "armhf" ]; then
+        exit 0
+      fi
+      cd "\$CRAFT_PART_SRC"
+      archive="${NODE_SOURCE_ARCHIVE}"
+      curl -sSL --show-error --fail --proto '=https' --tlsv1.2 \
+        --output "\$archive" "${NODE_DOWNLOAD_BASE}/\$archive"
+      echo "${NODE_SOURCE_CHECKSUM}  \$archive" | sha256sum --check --strict -
+      tar -xJf "\$archive" --strip-components=1
+      rm "\$archive"
     override-build: |
+      if [ "${NODE_ARMHF_MODE}" != "source" ] || [ "\$CRAFT_ARCH_BUILD_FOR" != "armhf" ]; then
+        exit 0
+      fi
       rustup toolchain install "\$RUSTUP_TOOLCHAIN" --profile minimal
       ./configure --verbose --prefix=/ --release-urlbase=https://nodejs.org/download/${NODE_DISTTYPE}/ --tag=${NODE_TAG} --v8-enable-temporal-support
       craftctl default
-      mkdir -p \$CRAFT_PART_INSTALL/etc
-      echo "prefix = /usr/local" >> \$CRAFT_PART_INSTALL/etc/npmrc
+      mkdir -p "\$CRAFT_PART_INSTALL/etc"
+      echo "prefix = /usr/local" >> "\$CRAFT_PART_INSTALL/etc/npmrc"
 EOF
 
 if [ "X${UPDATE_GIT}" = "Xyes" ] && [ -n "$(git status --porcelain "$__dirname")" ]; then

--- a/snapcraft.yaml.sh
+++ b/snapcraft.yaml.sh
@@ -3,7 +3,6 @@
 set -euxo pipefail
 
 __dirname="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-UPDATE_GIT=no
 
 select_node_version() {
   local index_url="$1"
@@ -65,7 +64,7 @@ checksum_for() {
 NODE_REQUIRED_FILES="src,linux-arm64,linux-s390x,linux-x64"
 NODE_ARMHF_MODE=source
 
-while getopts "r:g:" opt; do
+while getopts ":r:" opt; do
   case $opt in
     r)
       echo "Updating for latest $OPTARG release" >&2
@@ -77,18 +76,13 @@ while getopts "r:g:" opt; do
       fi
       NODE_VERSION="$(select_node_version "https://nodejs.org/download/release/index.tab" "$OPTARG" "$NODE_REQUIRED_FILES")"
       ;;
-    g)
-      echo "Pushing to git $OPTARG" >&2
-      UPDATE_GIT=yes
-      GIT_BRANCH=$OPTARG
-      REMOTE_BRANCH=$GIT_BRANCH
-      if [ "X${GIT_BRANCH}" = "Xmain" ]; then
-        REMOTE_BRANCH=master
-      fi
+    :)
+      echo "Option -$OPTARG requires an argument" >&2
+      exit 1
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
-      exit
+      exit 1
   esac
 done
 
@@ -115,19 +109,10 @@ if [ "$NODE_ARMHF_MODE" = "prebuilt" ]; then
   NODE_ARMHF_CHECKSUM="$(checksum_for "$NODE_ARMHF_ARCHIVE")"
 fi
 
-
 echo "NODE_VERSION=$NODE_VERSION"
 echo "NODE_DISTTYPE=$NODE_DISTTYPE"
 echo "NODE_TAG=$NODE_TAG"
 
-if [ "X${UPDATE_GIT}" = "Xyes" ]; then
-  git clean -fdx
-  git reset HEAD --hard
-  git fetch origin
-  git checkout "origin/$GIT_BRANCH" --force
-  git branch -D "$GIT_BRANCH" || true
-  git checkout -b "$GIT_BRANCH"
-fi
 
 # Write snapcraft.yaml for this config
 
@@ -263,9 +248,3 @@ parts:
       echo "prefix = /usr/local" >> "\$CRAFT_PART_INSTALL/etc/npmrc"
 EOF
 
-if [ "X${UPDATE_GIT}" = "Xyes" ] && [ -n "$(git status --porcelain "$__dirname")" ]; then
-  echo "Updating git repo and pushing ..."
-  git commit "$__dirname" -m "snap: (auto) updated to ${NODE_VERSION}"
-  git push origin "$GIT_BRANCH"
-  git push launchpad "$GIT_BRANCH:$REMOTE_BRANCH"
-fi


### PR DESCRIPTION
## Summary

- package official Node.js binaries on amd64, arm64, and s390x without rewriting their host loader or runtime search paths
- retain an Experimental source build for armhf, while supporting the official armv7l artifact on Node.js 22
- select only complete release/nightly artifact sets and embed their published SHA-256 checksums
- provide Node.js 25+'s `libatomic.so.1` dependency in an isolated directory and resolve nested Node/npm commands directly inside the Snap
- make the scheduled publisher serialize per branch, remove its self-triggering push event, and keep Git operations out of the generator
- document the artifact, architecture, and publishing model

Refs #54.

## Validation

Launchpad recipe [`nodeedge-runtime-test`](https://launchpad.net/~openjs/+snap/nodeedge-runtime-test) built commit `5e507d3` successfully on all supported processors:

- [amd64](https://launchpad.net/~openjs/+snap/nodeedge-runtime-test/+build/3213770): 17m 19s
- [arm64](https://launchpad.net/~openjs/+snap/nodeedge-runtime-test/+build/3213772): 12m 25s
- [armhf](https://launchpad.net/~openjs/+snap/nodeedge-runtime-test/+build/3213771): 1h 41m
- [s390x](https://launchpad.net/~openjs/+snap/nodeedge-runtime-test/+build/3213773): 14m 13s

Artifact checks:

- amd64, arm64, and s390x packaged Node binaries are byte-identical to the checksummed upstream artifacts
- supported binaries retain their host interpreters and contain no RPATH/RUNPATH
- armhf uses the core24 loader and architecture-aware patched RPATH
- amd64 resolves only `libatomic.so.1` from the Snap; libc and libstdc++ resolve from the host
- Node.js 27, Temporal, npm, npx, child Node dispatch, npm lifecycle host commands, and a host-built N-API addon passed on amd64
- Yarn is absent
- edge, Node.js 26, 24, and 22 generator modes passed; Node.js 22 selected its official armv7l artifact
- the exact workflow generation and local-repository publishing scripts passed focused harness tests

The intended rollout is edge first, then Node.js 26, followed by Node.js 24.